### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.CustomerReviews.ExperienceApi/Commands/CreateReviewCommandBuilder.cs
+++ b/src/VirtoCommerce.CustomerReviews.ExperienceApi/Commands/CreateReviewCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using MediatR;
@@ -14,8 +15,14 @@ public class CreateReviewCommandBuilder : CommandBuilder<CreateReviewCommand, Cr
 {
     protected override string Name => "createReview";
 
+    public CreateReviewCommandBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public CreateReviewCommandBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.CustomerReviews.ExperienceApi/Queries/CanLeaveFeedbackQueryBuilder.cs
+++ b/src/VirtoCommerce.CustomerReviews.ExperienceApi/Queries/CanLeaveFeedbackQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
@@ -12,8 +13,14 @@ public class CanLeaveFeedbackQueryBuilder : QueryBuilder<CanLeaveFeedbackQuery, 
 {
     protected override string Name => "canLeaveFeedback";
 
+    public CanLeaveFeedbackQueryBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public CanLeaveFeedbackQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 

--- a/src/VirtoCommerce.CustomerReviews.ExperienceApi/Queries/CustomerReviewQueryBuilder.cs
+++ b/src/VirtoCommerce.CustomerReviews.ExperienceApi/Queries/CustomerReviewQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.CustomerReviews.Core.Models;
@@ -10,7 +11,12 @@ public class CustomerReviewQueryBuilder : SearchQueryBuilder<CustomerReviewsQuer
 {
     protected override string Name => "customerReviews";
 
-    public CustomerReviewQueryBuilder(IMediator mediator, IAuthorizationService authorizationService) : base(mediator, authorizationService)
+    public CustomerReviewQueryBuilder(IAuthorizationService authorizationService) : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public CustomerReviewQueryBuilder(IMediator mediator, IAuthorizationService authorizationService) : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.CustomerReviews.ExperienceApi/VirtoCommerce.CustomerReviews.ExperienceApi.csproj
+++ b/src/VirtoCommerce.CustomerReviews.ExperienceApi/VirtoCommerce.CustomerReviews.ExperienceApi.csproj
@@ -10,7 +10,7 @@
     
     <PackageReference Include="VirtoCommerce.FileExperienceApi.Data" Version="3.1003.0" />
     <PackageReference Include="VirtoCommerce.ProfileExperienceApiModule.Data" Version="3.1009.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
     <PackageReference Include="VirtoCommerce.XCatalog.Core" Version="3.1007.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.CustomerReviews.Web/module.manifest
+++ b/src/VirtoCommerce.CustomerReviews.Web/module.manifest
@@ -14,7 +14,7 @@
     <dependency id="VirtoCommerce.Orders" version="3.1009.0" />
     <dependency id="VirtoCommerce.ProfileExperienceApiModule" version="3.1009.0" />
     <dependency id="VirtoCommerce.Store" version="3.1005.0" />
-    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
     <dependency id="VirtoCommerce.XCatalog" version="3.1007.0" />
   </dependencies>
 


### PR DESCRIPTION
## Description

GraphQL command and query builders are created once while the schema is built. Injecting `IMediator` into their constructors captures the root service provider; a request dispatched through it can therefore resolve scoped handler dependencies from the wrong scope.

This change upgrades XApi to `3.1015.0`. Its base builders resolve the mediator from the active GraphQL request through `context.GetMediator()` immediately before dispatch. `CreateReviewCommandBuilder`, `CustomerReviewQueryBuilder`, and `CanLeaveFeedbackQueryBuilder` now use the mediator-free constructor path.

The previous constructors that accept `IMediator` remain as obsolete compatibility overloads. They delegate to the mediator-free constructors, so existing consumers continue to compile without retaining a mediator in a singleton.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.CustomerReviews_3.1005.0-pr-81-050b.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request dispatch for review create/search and feedback authorization paths; the change corrects scoped-service usage but alters how handlers are resolved at runtime.
> 
> **Overview**
> Fixes **incorrect DI scope** for customer-review GraphQL operations by stopping `IMediator` injection into long-lived schema builders and relying on **per-request** mediator resolution from the upgraded XApi base types.
> 
> **VirtoCommerce.Xapi** / **Xapi.Core** are bumped from `3.1012.0` to `3.1015.0` (package reference and `module.manifest`). `CreateReviewCommandBuilder`, `CanLeaveFeedbackQueryBuilder`, and `CustomerReviewQueryBuilder` now take only `IAuthorizationService` and call the mediator-free base constructors. The previous `IMediator` constructors remain as **`[Obsolete]`** overloads that forward to the new constructors so existing registrations still compile without holding a root-scoped mediator on singleton builders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 050bf0945e043794f5a76ff720207ff66a3ddd0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->